### PR TITLE
Claude Codeで利用するmodelをOpus 4.5に変更する

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,4 +41,5 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+          claude_args: '--model claude-opus-4-5-20251101'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,4 +47,5 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: '--model claude-opus-4-5-20251101'
 


### PR DESCRIPTION
## Summary
- Claude Code GitHub Actionで使用するモデルをOpus 4.5 (`claude-opus-4-5-20251101`) に変更

## Changes
- `.github/workflows/claude.yml` に `claude_args: '--model claude-opus-4-5-20251101'` を追加
- `.github/workflows/claude-code-review.yml` に `claude_args: '--model claude-opus-4-5-20251101'` を追加

## Test plan
- [ ] PRをマージ後、issue/PRで `@claude` をメンションして動作確認
- [ ] PRを作成してCode Reviewが正常に動作することを確認

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)