### PR TITLE
GitHub MCPを追加してissue/PR操作を可能にする

### DIFF
--- a/.github/mcp-servers.json
+++ b/.github/mcp-servers.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "${GH_TOKEN}" }
+    }
+  }
+}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -49,18 +49,4 @@ jobs:
           claude_args: |
             --model claude-opus-4-5-20251101
             --mcp-config .github/mcp-servers.json
-            --allowedTools \
-              Bash, Write, Edit, MultiEdit, Read, LS, Glob, Grep, WebFetch\
-              mcp__github__create_branch,\
-              mcp__github__issue_read,\
-              mcp__github__issue_write,\
-              mcp__github__sub_issue_write,\
-              mcp__github__list_sub_issues,\
-              mcp__github__create_pull_request,\
-              mcp__github__get_pull_request,\
-              mcp__github__get_pull_request_diff,\
-              mcp__github__pull_request_read,\
-              mcp__github__update_pull_request,\
-              mcp__github__create_pending_pull_request_review,\
-              mcp__github__add_comment_to_pending_review,\
-              mcp__github__submit_pending_pull_request_review
+            --allowedTools "Bash,Write,Edit,MultiEdit,Read,LS,Glob,Grep,WebFetch,mcp__github__create_branch,mcp__github__issue_read,mcp__github__issue_write,mcp__github__sub_issue_write,mcp__github__list_sub_issues,mcp__github__create_pull_request,mcp__github__get_pull_request,mcp__github__get_pull_request_diff,mcp__github__pull_request_read,mcp__github__update_pull_request,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,21 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: |
+            --mcp-config .github/mcp-servers.json
+            --allowedTools \
+              Bash, Write, Edit, MultiEdit, Read, LS, Glob, Grep, WebFetch\
+              mcp__github__create_branch,\
+              mcp__github__issue_read,\
+              mcp__github__issue_write,\
+              mcp__github__sub_issue_write,\
+              mcp__github__list_sub_issues,\
+              mcp__github__create_pull_request,\
+              mcp__github__get_pull_request,\
+              mcp__github__get_pull_request_diff,\
+              mcp__github__pull_request_read,\
+              mcp__github__update_pull_request,\
+              mcp__github__create_pending_pull_request_review,\
+              mcp__github__add_comment_to_pending_review,\
+              mcp__github__submit_pending_pull_request_review
 


### PR DESCRIPTION
## Summary
- GitHub MCP (Model Context Protocol) を追加し、Claude CodeからGitHub操作を可能にする

## Changes
- `.github/mcp-servers.json` を新規作成（GitHub MCP サーバー設定）
- `.github/workflows/claude.yml` に以下を追加:
  - `--mcp-config .github/mcp-servers.json` でMCP設定を読み込み
  - `--allowedTools` で許可するツールを指定:
    - 基本ツール: Bash, Write, Edit, MultiEdit, Read, LS, Glob, Grep, WebFetch
    - ブランチ作成: `mcp__github__create_branch`
    - Issue操作: `mcp__github__issue_read`, `mcp__github__issue_write`
    - Sub-issue操作: `mcp__github__sub_issue_write`, `mcp__github__list_sub_issues`
    - PR操作: `mcp__github__create_pull_request`, `mcp__github__get_pull_request`, `mcp__github__get_pull_request_diff`, `mcp__github__pull_request_read`, `mcp__github__update_pull_request`
    - レビュー操作: `mcp__github__create_pending_pull_request_review`, `mcp__github__add_comment_to_pending_review`, `mcp__github__submit_pending_pull_request_review`

## Test plan
- [ ] PRマージ後、issueで `@claude` をメンションしてissue操作ができることを確認
- [ ] PRで `@claude` をメンションしてPR操作ができることを確認

## Reference
- https://techblog.insightedge.jp/entry/spec-kit-sdd-with-github

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)