### PR TITLE
fetch-depthを0に設定して完全なgit履歴を取得

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Summary
- `claude.yml` と `claude-code-review.yml` の `fetch-depth` を 0 に設定
- 完全なgit履歴を取得することで、Claudeがより多くのコンテキストを得られるようにする

## Changes
- `.github/workflows/claude.yml`: `fetch-depth: 1` → `fetch-depth: 0`
- `.github/workflows/claude-code-review.yml`: `fetch-depth: 1` → `fetch-depth: 0`

## Test plan
- [ ] PRマージ後、Claude Codeがgit履歴を参照できることを確認

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)